### PR TITLE
refactor : 범위 이탈 판정 함수 IsOutOfBound 개선

### DIFF
--- a/WinAPI-AirForce1945/CObject.cpp
+++ b/WinAPI-AirForce1945/CObject.cpp
@@ -20,20 +20,21 @@ void CObject::UpdateRect()
 	m_tRect.bottom = static_cast<LONG>(m_vPivot.y + (m_vSize.y * 0.5f));
 }
 
-OUTOFRANGE_DIR CObject::IsOutOfRange(const int _iMargin)
+tagObjBound CObject::IsOutOfBound(const int _iMargin)
 {
+	tagObjBound tObjBound = {};
 
 	if (m_tRect.left < 0 - _iMargin)
-		return OUTOFRANGE_DIR::OUT_LEFT;
+		tObjBound.bIsOutLeft = true;
 
 	if (m_tRect.right > WINCX + _iMargin)
-		return OUTOFRANGE_DIR::OUT_RIGHT;
+		tObjBound.bIsOutRight = true;
 
 	if (m_tRect.top < 0 - _iMargin)
-		return OUTOFRANGE_DIR::OUT_TOP;
+		tObjBound.bIsOutTop = true;
 
 	if (m_tRect.bottom > WINCY + _iMargin)
-		return OUTOFRANGE_DIR::OUT_BOTTOM;
+		tObjBound.bIsOutBottom = true;
 
-	return OUTOFRANGE_DIR::INSIDE;
+	return tObjBound;
 }

--- a/WinAPI-AirForce1945/CObject.h
+++ b/WinAPI-AirForce1945/CObject.h
@@ -34,20 +34,15 @@ protected:
 	/**
 	* \brief 오브젝트가 있어야 할 범위를 벗어났는지 여부를 확인하는 함수
 	*
-	* 주로 LateUpdate()에서 호출하며, 필요할 경우에만 사용할 것
+	* 주로 LateUpdate()에서 호출하며, 범위 밖으로 나갈 시 오브젝트 제거 등 다양하게 사용 가능
 	*
-	* \param	_iMargin	경계선 판정 시 적용할 여유값
+	* \param	_iMargin
+	* 경계선 판정 시 경계를 늘리거나 줄이는 데 사용. 디폴트로 사용 시 정해진 화면과 동일한 범위
 	*
-	* \return
-	* - INSIDE:		범위 안에 있음
-	* - OUT_LEFT:		화면 기준 왼쪽으로 범위 이탈
-	* - OUT_RIGHT:		화면 기준 오른쪽으로 범위 이탈
-	* - OUT_TOP:		화면 기준 위쪽으로 범위 이탈
-	* - OUT_BOTTOM:		화면 기준 아래쪽으로 범위 이탈
-	*
-	* \note _iMargin 값에 따라 자식 클래스에서 HandleOutOfRange()를 조정할 것
+	* \return	tagObjBound:
+	* 범위 밖으로 나갈 시 각 방향의 bool값이 true가 되는 구조체
 	*/
-	OUTOFRANGE_DIR		IsOutOfRange(const int _iMargin = 0);
+	tagObjBound	IsOutOfBound(const int _iMargin = 0);
 
 protected:
 	RECT			m_tRect;

--- a/WinAPI-AirForce1945/CPlayer.cpp
+++ b/WinAPI-AirForce1945/CPlayer.cpp
@@ -37,7 +37,7 @@ int CPlayer::Update()
 
 void CPlayer::LateUpdate()
 {
-	HandleOutOfRange(IsOutOfRange());
+	HandleOutOfBound(IsOutOfBound());
 }
 
 void CPlayer::Render(HDC _hDC)
@@ -138,20 +138,17 @@ void CPlayer::Key_Input()
 	}
 }
 
-void CPlayer::HandleOutOfRange(const OUTOFRANGE_DIR eOutDir)
+void CPlayer::HandleOutOfBound(const tagObjBound tOutDir)
 {
-	if (eOutDir == OUTOFRANGE_DIR::INSIDE)
-		return;
-
-	if (eOutDir == OUTOFRANGE_DIR::OUT_LEFT)
+	if (tOutDir.bIsOutLeft)
 		m_vPivot.x += static_cast<float>(0 - m_tRect.left);
 
-	if (eOutDir == OUTOFRANGE_DIR::OUT_RIGHT)
+	if (tOutDir.bIsOutRight)
 		m_vPivot.x -= static_cast<float>(m_tRect.right - WINCX);
 
-	if (eOutDir == OUTOFRANGE_DIR::OUT_TOP)
+	if (tOutDir.bIsOutTop)
 		m_vPivot.y += static_cast<float>(0 - m_tRect.top);
 
-	if (eOutDir == OUTOFRANGE_DIR::OUT_BOTTOM)
+	if (tOutDir.bIsOutBottom)
 		m_vPivot.y -= static_cast<float>(m_tRect.bottom - WINCY);
 }

--- a/WinAPI-AirForce1945/CPlayer.h
+++ b/WinAPI-AirForce1945/CPlayer.h
@@ -15,12 +15,12 @@ public:
 	void Release() override;
 
 public:
-	int   GetLife() const { return m_iLife; }
-	int   GetPower() const { return m_iPower; }
-	bool  GetIsAlive() const { return m_bIsAlive; }
-	bool  GetIsInvincible() const { return m_bIsInvincible; }
-	DWORD GetAttackCooldown() const { return m_dwAttackCooldown; }
-	DWORD GetLastAttackTime() const { return m_dwLastAttackTime; }
+	int       GetLife() const { return m_iLife; }
+	int       GetPower() const { return m_iPower; }
+	bool      GetIsAlive() const { return m_bIsAlive; }
+	bool      GetIsInvincible() const { return m_bIsInvincible; }
+	ULONGLONG GetAttackCooldown() const { return m_dwAttackCooldown; }
+	ULONGLONG GetLastAttackTime() const { return m_dwLastAttackTime; }
 
 	// SetLife는 플레이어 생성, 부활 등에 사용할 것. Life 추가는 AddLife 함수 사용 바람
 	void SetLife(const int _iLife) { m_iLife = _iLife; }
@@ -28,8 +28,8 @@ public:
 	void SetPower(const int _iPower) { m_iLife = _iPower; }
 	void SetIsAlive(const bool _bIsAlive) { m_bIsAlive = _bIsAlive; }
 	void SetIsInvincible(const bool _bIsInvincible) { m_bIsInvincible = _bIsInvincible; }
-	void SetAttackCooldown(const DWORD _dwAttackCooldown) { m_dwAttackCooldown = _dwAttackCooldown; }
-	void SetLastAttackTime(const DWORD _dwLastAttackTime) { m_dwLastAttackTime = _dwLastAttackTime; }
+	void SetAttackCooldown(const ULONGLONG _dwAttackCooldown) { m_dwAttackCooldown = _dwAttackCooldown; }
+	void SetLastAttackTime(const ULONGLONG _dwLastAttackTime) { m_dwLastAttackTime = _dwLastAttackTime; }
 
 public:
 	bool OnCollision(CObject* _pColObj) override;
@@ -41,8 +41,8 @@ public:
 private:
 	void Key_Input();
 	// 화면 밖으로 나가지 않게 만드는 기능의 함수
-	void HandleOutOfRange(const OUTOFRANGE_DIR eOutDir);
-	
+	void HandleOutOfBound(const tagObjBound tOutDir);
+
 private:
 	list<CObject*>* m_pBullet;
 	list<CObject*>* m_pShield;
@@ -55,6 +55,6 @@ private:
 	bool m_bIsAlive;
 	bool m_bIsInvincible;		// 피격, 부활 시 true -> 무적
 
-	DWORD m_dwAttackCooldown;	// 공격간 딜레이 설정
-	DWORD m_dwLastAttackTime;	// 마지막 공격 시간 저장
+	ULONGLONG m_dwAttackCooldown;	// 공격간 딜레이 설정
+	ULONGLONG m_dwLastAttackTime;	// 마지막 공격 시간 저장
 };

--- a/WinAPI-AirForce1945/Define.h
+++ b/WinAPI-AirForce1945/Define.h
@@ -32,15 +32,21 @@ enum COLLISION_FLAG
 	COL_FLAG_END
 };
 
-enum OUTOFRANGE_DIR
+/**
+ * \brief 각 사방의 범위 밖으로 나갈 경우를 체크하기 위한 구조체
+ *
+ * \details
+ * - bIsOutLeft:	왼쪽으로 벗어난 경우 true
+ * - bIsOutRight:	오른쪽으로 벗어난 경우 true
+ * - bIsOutTop:	위쪽으로 벗어난 경우 true
+ * - bIsOutBottom:	아래쪽으로 벗어난 경우 true
+ */
+struct tagObjBound
 {
-	INSIDE,
-	OUT_LEFT,
-	OUT_RIGHT,
-	OUT_TOP,
-	OUT_BOTTOM,
-
-	OUT_DIR_END
+	bool bIsOutLeft = false;
+	bool bIsOutRight = false;
+	bool bIsOutTop = false;
+	bool bIsOutBottom = false;
 };
 
 template <typename T>

--- a/WinAPI-AirForce1945/Vector2.h
+++ b/WinAPI-AirForce1945/Vector2.h
@@ -1,7 +1,7 @@
 ﻿#pragma once
 #include <cmath>
 
-typedef struct Vector2
+struct Vector2
 {
 public:
 	Vector2() : x(0.f), y(0.f) { };


### PR DESCRIPTION
공용 코드 변경 부분 :
- Vector2 구조체에 의미없이 붙어있던 typedef 제거
- Difine.h 에 추가했던 enum OUTOFRANGE_DIR를 제거하고, 그 기능을 struct tagObjBound가 대신하도록 수정