### PR TITLE
feat : Bullet 자식 클래스 부분 수정, 플레이어 체력 상한, 체이서 발사 간격 추가

### DIFF
--- a/WinAPI-AirForce1945/CMonster.cpp
+++ b/WinAPI-AirForce1945/CMonster.cpp
@@ -3,7 +3,6 @@
 
 CMonster::CMonster() : iHp(0), fPlayerVX(0.f), fPlayerVY(0.f), m_pBullet(nullptr), ull_wLastShotTime(0)
 {
-
 }
 CMonster::~CMonster()
 {

--- a/WinAPI-AirForce1945/CMonster.h
+++ b/WinAPI-AirForce1945/CMonster.h
@@ -3,6 +3,7 @@
 
 #include "CAbstractFactory.h"
 #include "CNormalBullet.h"
+
 class CMonster : public CObject
 {
 protected:
@@ -27,7 +28,7 @@ public:
 
 	/*virtual void ShootBullet() PURE;*/
 
-	int getHp() const { return iHp; }
+	int  getHp() const { return iHp; }
 	void setHp(short _iHp) { iHp = _iHp; }
 	void setPlayerVXY(CObject* pObj) { fPlayerVX = pObj->GetPivot().x; fPlayerVY = pObj->GetPivot().y; }
 	void SetBullet(list<CObject*>* _m_pBullet) { m_pBullet = _m_pBullet; }

--- a/WinAPI-AirForce1945/CNormalBullet.cpp
+++ b/WinAPI-AirForce1945/CNormalBullet.cpp
@@ -11,10 +11,6 @@ CNormalBullet::~CNormalBullet()
 
 void CNormalBullet::Initialize()
 {
-	m_eObjectType = OBJECT_TYPE::PLAYER_BULLET;
-
-	//todo 플레이어쪽인지 몬스터 쪽인지는 Create를 새로 만들어서 전달하면 좋을듯?
-
 	m_vSize     = { 15.f, 15.f };
 	m_fSpeed    = 10.f;
 	m_fShootDeg = 90.f;

--- a/WinAPI-AirForce1945/CPlayer.cpp
+++ b/WinAPI-AirForce1945/CPlayer.cpp
@@ -9,7 +9,7 @@
 CPlayer::CPlayer()
 	: m_pBullet(nullptr), m_pShield(nullptr),
 	  m_iLife(0), m_iMaxLife(0), m_iPower(0), m_iMaxPower(0),
-	  m_qwAttackCooldown(0), m_qwLastAttackTime(0),
+	  m_qwAttackCooldown(0), m_qwLastAttackTime(0), m_qwChaserCooldown(0),
 	  m_qwInvincibleDuration(0), m_qwInvincibleEndTime(0),
 	  m_bIsAlive(false), m_bIsInvincible(false)
 {}
@@ -32,6 +32,7 @@ void CPlayer::Initialize()
 	m_iMaxPower = PL_MAXPOWER;
 
 	m_qwAttackCooldown     = 150;
+	m_qwChaserCooldown     = 400;
 	m_qwInvincibleDuration = 500;
 
 	m_bIsAlive = true;
@@ -128,7 +129,6 @@ bool CPlayer::OnCollision(CObject* _pObjCol)
 	break;
 	case OBJECT_TYPE::MONSTER_BULLET:
 	{
-		//todo 몬스터 총알만 판정하도록
 		this->AddLife(-1);
 	}
 	break;
@@ -188,6 +188,18 @@ void CPlayer::KeyInput(const tagObjBound _tOutDir)
 			ShootBullet();
 
 			m_qwLastAttackTime = qwCurrentTime;
+		}
+
+		if (m_iPower >= 5 && qwCurrentTime - m_qwLastChaserAttackTime >= m_qwChaserCooldown)
+		{
+			m_pBullet->push_back(CAbstractFactory<CChaserBullet>::Create(
+				m_vPivot.x,
+				m_vPivot.y - m_vSize.y / 2,
+				OBJECT_TYPE::PLAYER_BULLET,
+				15.f,
+				90.f));
+
+			m_qwLastChaserAttackTime = qwCurrentTime;
 		}
 	}
 
@@ -312,12 +324,12 @@ void CPlayer::ShootBullet()
 			m_vPivot.x + 16, m_vPivot.y - m_vSize.y / 2, OBJECT_TYPE::PLAYER_BULLET, 10.f, 84.f));
 
 		m_pBullet->push_back(CAbstractFactory<CRotateBullet>::Create(
-			m_vPivot.x, m_vPivot.y - m_vSize.y / 2, OBJECT_TYPE::PLAYER_BULLET, 50.f, 90.f));
+			m_vPivot.x, m_vPivot.y - m_vSize.y / 2, OBJECT_TYPE::PLAYER_BULLET, 10.f, 90.f));
 	}
 	break;
 	case 5:
 	{
-		m_qwAttackCooldown = 50;
+		m_qwAttackCooldown = 75;
 
 		m_pBullet->push_back(CAbstractFactory<CNormalBullet>::Create(
 			m_vPivot.x - 10, m_vPivot.y - m_vSize.y / 2, OBJECT_TYPE::PLAYER_BULLET, 15.f, 90.f));
@@ -329,8 +341,6 @@ void CPlayer::ShootBullet()
 			m_vPivot.x + 5, m_vPivot.y - m_vSize.y / 2, OBJECT_TYPE::PLAYER_BULLET, 15.f, 90.f));
 		m_pBullet->push_back(CAbstractFactory<CNormalBullet>::Create(
 			m_vPivot.x + 10, m_vPivot.y - m_vSize.y / 2, OBJECT_TYPE::PLAYER_BULLET, 15.f, 90.f));
-		m_pBullet->push_back(CAbstractFactory<CChaserBullet>::Create(
-			m_vPivot.x, m_vPivot.y - m_vSize.y / 2, OBJECT_TYPE::PLAYER_BULLET, 15.f, 90.f));
 	}
 	break;
 	default:

--- a/WinAPI-AirForce1945/CPlayer.cpp
+++ b/WinAPI-AirForce1945/CPlayer.cpp
@@ -7,9 +7,11 @@
 #include "CChaserBullet.h"
 
 CPlayer::CPlayer()
-	: m_pBullet(nullptr), m_pShield(nullptr), m_iLife(0), m_iPower(0), m_iMaxPower(0),
-	  m_qwAttackCooldown(150), m_qwLastAttackTime(0), m_dwInvincibleDuration(0), m_qwInvincibleEndTime(0),
-	  m_bIsAlive(true), m_bIsInvincible(false)
+	: m_pBullet(nullptr), m_pShield(nullptr),
+	  m_iLife(0), m_iMaxLife(0), m_iPower(0), m_iMaxPower(0),
+	  m_qwAttackCooldown(0), m_qwLastAttackTime(0),
+	  m_qwInvincibleDuration(0), m_qwInvincibleEndTime(0),
+	  m_bIsAlive(false), m_bIsInvincible(false)
 {}
 
 CPlayer::~CPlayer()
@@ -26,7 +28,13 @@ void CPlayer::Initialize()
 	m_fSpeed = 8.f;
 
 	m_iLife     = PL_LIFE;
+	m_iMaxLife  = 3;
 	m_iMaxPower = PL_MAXPOWER;
+
+	m_qwAttackCooldown     = 150;
+	m_qwInvincibleDuration = 500;
+
+	m_bIsAlive = true;
 }
 
 int CPlayer::Update()
@@ -103,7 +111,7 @@ void CPlayer::Revive()
 	m_bIsInvincible = true;
 	m_bIsAlive      = true;
 
-	m_qwInvincibleEndTime = GetTickCount64() + m_dwInvincibleDuration;
+	m_qwInvincibleEndTime = GetTickCount64() + m_qwInvincibleDuration;
 }
 
 bool CPlayer::OnCollision(CObject* _pObjCol)
@@ -153,6 +161,8 @@ void CPlayer::AddLife(const int _iLifeChange)
 
 	if (m_iLife < 0)
 		m_iLife = 0;
+	else if (m_iLife > m_iMaxLife)
+		m_iLife = m_iMaxLife;
 }
 
 void CPlayer::AddPower(const int _iPowerChange)
@@ -248,8 +258,6 @@ void CPlayer::ShootBullet()
 
 		m_pBullet->push_back(CAbstractFactory<CNormalBullet>::Create(
 			m_vPivot.x, m_vPivot.y - m_vSize.y / 2, OBJECT_TYPE::PLAYER_BULLET, 10.f, 90.f));
-
-		
 	}
 	break;
 	case 1:

--- a/WinAPI-AirForce1945/CPlayer.cpp
+++ b/WinAPI-AirForce1945/CPlayer.cpp
@@ -28,7 +28,7 @@ void CPlayer::Initialize()
 	m_fSpeed = 8.f;
 
 	m_iLife     = PL_LIFE;
-	m_iMaxLife  = 3;
+	m_iMaxLife  = PL_LIFE;
 	m_iMaxPower = PL_MAXPOWER;
 
 	m_qwAttackCooldown     = 150;

--- a/WinAPI-AirForce1945/CPlayer.h
+++ b/WinAPI-AirForce1945/CPlayer.h
@@ -51,13 +51,14 @@ private:
 	list<CObject*>* m_pShield;
 
 	int m_iLife;
+	int m_iMaxLife;
 	int m_iPower;
 	int m_iMaxPower;
 
 	ULONGLONG m_qwAttackCooldown;		// 공격간 딜레이 설정
 	ULONGLONG m_qwLastAttackTime;		// 마지막 공격 시간 저장
 
-	ULONGLONG m_dwInvincibleDuration;	// 무적 지속 시간 설정
+	ULONGLONG m_qwInvincibleDuration;	// 무적 지속 시간 설정
 	ULONGLONG m_qwInvincibleEndTime;	// 무적 끝나는 시간 저장
 
 	bool m_bIsAlive;

--- a/WinAPI-AirForce1945/CPlayer.h
+++ b/WinAPI-AirForce1945/CPlayer.h
@@ -45,6 +45,7 @@ public:
 private:
 	void KeyInput(const tagObjBound _tOutDir);
 	void ShootBullet();
+	void ShootChaser();
 
 private:
 	list<CObject*>* m_pBullet;
@@ -55,12 +56,15 @@ private:
 	int m_iPower;
 	int m_iMaxPower;
 
-	ULONGLONG m_qwAttackCooldown;		// 공격간 딜레이 설정
-	ULONGLONG m_qwLastAttackTime;		// 마지막 공격 시간 저장
+	ULONGLONG m_qwAttackCooldown;			// 공격간 딜레이 설정
+	ULONGLONG m_qwLastAttackTime;			// 마지막 공격 시간 저장
 
-	ULONGLONG m_qwInvincibleDuration;	// 무적 지속 시간 설정
-	ULONGLONG m_qwInvincibleEndTime;	// 무적 끝나는 시간 저장
+	ULONGLONG m_qwChaserCooldown;			// 체이서 공격간 딜레이 설정
+	ULONGLONG m_qwLastChaserAttackTime;		// 마지막 체이서 공격 시간 저장
+
+	ULONGLONG m_qwInvincibleDuration;		// 무적 지속 시간 설정
+	ULONGLONG m_qwInvincibleEndTime;		// 무적 끝나는 시간 저장
 
 	bool m_bIsAlive;
-	bool m_bIsInvincible;				// 피격, 부활 시 true -> 무적
+	bool m_bIsInvincible;					// 피격, 부활 시 true -> 무적
 };

--- a/WinAPI-AirForce1945/CRazorBullet.cpp
+++ b/WinAPI-AirForce1945/CRazorBullet.cpp
@@ -11,10 +11,6 @@ CRazorBullet::~CRazorBullet()
 
 void CRazorBullet::Initialize()
 {
-	m_eObjectType = OBJECT_TYPE::PLAYER_BULLET;
-
-	//todo 플레이어쪽인지 몬스터 쪽인지는 Create를 새로 만들어서 전달하면 좋을듯?
-
 }
 
 int CRazorBullet::Update()

--- a/WinAPI-AirForce1945/CRotateBullet.cpp
+++ b/WinAPI-AirForce1945/CRotateBullet.cpp
@@ -12,10 +12,6 @@ CRotateBullet::~CRotateBullet()
 
 void CRotateBullet::Initialize()
 {
-	m_eObjectType = OBJECT_TYPE::PLAYER_BULLET;
-
-	//todo 플레이어쪽인지 몬스터 쪽인지는 Create를 새로 만들어서 전달하면 좋을듯?
-
 	m_vSize     = { 15.f, 15.f };
 	m_fSpeed    = 10.f;
 	m_fShootDeg = 90.f;

--- a/WinAPI-AirForce1945/WinAPI-AirForce1945.vcxproj.filters
+++ b/WinAPI-AirForce1945/WinAPI-AirForce1945.vcxproj.filters
@@ -145,7 +145,7 @@
       <Filter>헤더 파일</Filter>
     </ClInclude>
     <ClInclude Include="CChaserBullet.h">
-      <Filter>헤더 파일</Filter>
+      <Filter>01. Object\02. Bullet</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -222,7 +222,7 @@
       <Filter>소스 파일</Filter>
     </ClCompile>
     <ClCompile Include="CChaserBullet.cpp">
-      <Filter>소스 파일</Filter>
+      <Filter>01. Object\02. Bullet</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- 플레이어 체력 상한 설정, 각 하위 총알 수정
  - 각 하위 총알의 Initialize 에서 m_eObjectType을 직접 호출하던 부분을 삭제해서, 총알 Create 할 때 명시적으로 지정해야만 작동하도록 강제
- 플레이어가 체이서를 발사하는 간격을 개별 설정
